### PR TITLE
Fix status icons paths

### DIFF
--- a/src/background/browserActions.js
+++ b/src/background/browserActions.js
@@ -15,7 +15,7 @@ const button = {
 
 		for(var i in statuses)
 			for (var j in manifest.browser_action.default_icon)
-				statuses[i][j] = manifest.browser_action.default_icon[j].replace("idle", "/"+i);
+				statuses[i][j] = manifest.browser_action.default_icon[j].replace("idle", i);
 
 		statuses.idle = manifest.browser_action.default_icon;
 		if (__PLATFORM__=="firefox")


### PR DESCRIPTION
Due to an [extra `/` in the icon asset path](https://github.com/raindropio/extensions/blob/master/src/background/browserActions.js#L18), icons other than the default "idle" icon (which is defined separately in the manifest) do not render in Firefox. Chrome works OK - I think this is because Chrome strips out the extra `/`, whereas Firefox does not.

<img width="1392" alt="screenshot 2018-11-05 at 14 59 15" src="https://user-images.githubusercontent.com/1913316/47985755-4566f580-e10d-11e8-9da7-f36703a41b36.png">

Here is a log of the generated asset paths for the "saved" status icon:

<img width="866" alt="screenshot 2018-11-05 at 14 52 58" src="https://user-images.githubusercontent.com/1913316/47985772-59125c00-e10d-11e8-8a72-a08a37902942.png">

This PR removes the extra `/` in the string replacement operation, which renders the "saved" icon correctly when a URL is bookmarked:

<img width="1392" alt="screenshot 2018-11-05 at 14 58 41" src="https://user-images.githubusercontent.com/1913316/47985893-ac84aa00-e10d-11e8-8b9a-9a2e43b63321.png">

And here is the same log with the correct paths:

<img width="865" alt="screenshot 2018-11-05 at 14 57 57" src="https://user-images.githubusercontent.com/1913316/47985931-c58d5b00-e10d-11e8-89f7-22cdd4bd89ee.png">

Fixes #31