### PR TITLE
Add debounce to bookmark description textarea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/routes/edit/info.jsx
+++ b/src/routes/edit/info.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDom from 'react-dom'
 import t from 't'
-
+import debounce from 'lodash/debounce'
 import forms from '../../helpers/forms'
 
 import Icon from '../../co/common/icon'
@@ -16,7 +16,7 @@ export default class Info extends React.Component {
 		super(props);
 
 		this.goToCover = this.goToCover.bind(this);
-		this.inputChange = this.inputChange.bind(this);
+		this.inputChange = debounce(this.inputChange.bind(this), 100);
 
 		this.state = {
 			showExcerpt: true


### PR DESCRIPTION
While editing bookmark description spinner appears and disappears too often. It looks little annoying.
Just adding debounce to description textarea handler should solve this problem and decrease number of network requests.

![Peek 2020-03-19 10-51](https://user-images.githubusercontent.com/1172396/77030122-47fb7f80-69d0-11ea-9c79-5b1889c55e0c.gif)

I didn't tested it, but it should work :)